### PR TITLE
input/story.jsxのdecoratorsを削除

### DIFF
--- a/app/src/components/Atoms/Input/story.jsx
+++ b/app/src/components/Atoms/Input/story.jsx
@@ -12,10 +12,3 @@ export const Default = Template.bind({});
 Default.args = {
   onEditComplete: (value) => console.log("edit completed: ", value),
 };
-Default.decorators = [
-  (Story) => (
-    <div style={{ width: "232px" }}>
-      <Story />
-    </div>
-  ),
-];


### PR DESCRIPTION
inputのwidthを画面幅いっぱいにするための修正
Storybook上でのみwidthのstyleが指定されていたのでそこのコードを削除